### PR TITLE
Remove bad default for pytest filterwarnings

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -150,11 +150,6 @@ asyncio_default_fixture_loop_scope = "function"
 xfail_strict = true
 minversion = "7"
 log_cli_level = "INFO"
-filterwarnings = [
-    "error",
-    "ignore::DeprecationWarning",
-    "ignore::UserWarning",
-]
 testpaths = ["tests"]
 
 [tool.mypy]


### PR DESCRIPTION
## Description

<!--
- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Setting pytest to error on warning and then ignore two of the most common warnings defeat the whole purpose. 

